### PR TITLE
Upgrade bluefox SDK to version 2.40.2

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -5,7 +5,7 @@ MY_PATH=`dirname "$0"`
 MY_PATH=`( cd "$MY_PATH" && pwd )`
 
 DOWNLOAD_LINK="http://static.matrix-vision.com/mvIMPACT_Acquire"
-VERSION="2.34.0"
+VERSION="2.40.2"
 
 # install BLUEFOX
 UNAME_PROC=`uname -m`


### PR DESCRIPTION
Hi guys, I've just tested the cameras with the newest SDK. Everything compiles fine and the cameras run rock-solid (after updating all of them to firmware version 52).

I connected 4 of them to a Jetson Nano and it is not even needed to launch them in sequence with delays.